### PR TITLE
Add full authentication flow (register, activation, login, password reset) with guards

### DIFF
--- a/backend/auth_app/api/views.py
+++ b/backend/auth_app/api/views.py
@@ -7,9 +7,7 @@ from django.contrib.auth.tokens import (
     default_token_generator,
 )
 from django.core.mail import EmailMultiAlternatives, send_mail
-from django.http import HttpResponse
 from django.template.loader import render_to_string
-from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from rest_framework import status
@@ -38,14 +36,13 @@ class RegisterView(APIView):
         uid = urlsafe_base64_encode(force_bytes(str(user.pk)))
         token = default_token_generator.make_token(user)
 
-        activation_path = reverse("activate_account")
-
+        frontend_url = settings.FRONTEND_URL.rstrip("/")
         params = urlencode({
             "uid": uid,
             "token": token,
         })
 
-        activation_url = f"{request.scheme}://{request.get_host()}{activation_path}?{params}"
+        activation_url = f"{frontend_url}/activate?{params}"
         
         context = {
             "activation_url": activation_url,

--- a/backend/auth_app/api/views.py
+++ b/backend/auth_app/api/views.py
@@ -1,22 +1,29 @@
+from urllib.parse import urlencode
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.tokens import default_token_generator, PasswordResetTokenGenerator
+from django.contrib.auth.tokens import (
+    PasswordResetTokenGenerator,
+    default_token_generator,
+)
 from django.core.mail import EmailMultiAlternatives, send_mail
-from django.template.loader import render_to_string
 from django.http import HttpResponse
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.encoding import force_bytes
-from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
-
+from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
-from urllib.parse import urlencode
-
-from .serializers import RegisterSerializer, LoginSerializer, LogoutSerializer, ConfirmPasswordSerializer
+from .serializers import (
+    ConfirmPasswordSerializer,
+    LoginSerializer,
+    LogoutSerializer,
+    RegisterSerializer,
+)
 
 User = get_user_model()
 
@@ -135,7 +142,12 @@ class ResetPasswordView(APIView):
             uid = urlsafe_base64_encode(force_bytes(user.pk))
             token = PasswordResetTokenGenerator().make_token(user)
 
-            reset_url = f"{settings.FRONTEND_URL}/reset-password?uid={uid}&token={token}"
+            frontend_url = settings.FRONTEND_URL.rstrip("/")
+            params = urlencode({
+                "uid": uid,
+                "token": token,
+            })
+            reset_url = f"{frontend_url}/reset-password?{params}"
 
             send_mail(
                 subject="Reset your TalkCore password",
@@ -143,6 +155,9 @@ class ResetPasswordView(APIView):
                 from_email=settings.DEFAULT_FROM_EMAIL,
                 recipient_list=[user.email],
             )
+
+            # for development only -> remove in production
+            print("RESET PASSWORD URL:", reset_url)
 
         except User.DoesNotExist:
             pass

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -147,4 +147,4 @@ STATIC_URL = 'static/'
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 DEFAULT_FROM_EMAIL = "noreply@talkcore.local"
 
-FRONTEND_URL = 'http://127.0.0.1:5500/pages/auth/confirm-password.html'
+FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:4200")

--- a/backend/tests/auth/test_register.py
+++ b/backend/tests/auth/test_register.py
@@ -1,6 +1,7 @@
 import pytest
 
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 
 from rest_framework.test import APIClient
 
@@ -29,6 +30,23 @@ def test_register_success_creates_inactive_user_and_sends_activation_email(
     assert user.display_name == payload["display_name"]
     assert user.is_active is False
     assert len(mailoutbox) == 1
+
+
+@override_settings(FRONTEND_URL="http://localhost:4200")
+def test_register_activation_email_links_to_frontend(api_client, mailoutbox):
+    payload = {
+        "email": "user@example.com",
+        "display_name": "Tobias",
+        "password": "StrongPassword123",
+        "password_confirm": "StrongPassword123",
+    }
+
+    response = api_client.post(REGISTER_URL, payload, format="json")
+
+    assert response.status_code == 201
+    assert len(mailoutbox) == 1
+    assert "http://localhost:4200/activate?uid=" in mailoutbox[0].body
+    assert "/api/activate/" not in mailoutbox[0].body
 
 
 def test_register_fails_when_passwords_do_not_match(api_client):

--- a/backend/tests/auth/test_reset_password.py
+++ b/backend/tests/auth/test_reset_password.py
@@ -21,6 +21,8 @@ def test_reset_password_request_existing_email_sends_email_and_returns_200(api_c
 
     assert response.status_code == 200
     assert len(mailoutbox) == 1
+    assert "/reset-password?uid=" in mailoutbox[0].body
+    assert "&token=" in mailoutbox[0].body
 
 
 def test_reset_password_request_non_existing_email_still_returns_200(api_client, mailoutbox):

--- a/frontend/app/src/app/app.routes.ts
+++ b/frontend/app/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { AppShell } from '@core/layout/app-shell/app-shell';
 import { AuthShell } from '@core/layout/auth-shell/auth-shell';
+import { authGuard } from '@core/guards/auth-guard';
 
 export const routes: Routes = [
   {
@@ -15,7 +16,7 @@ export const routes: Routes = [
   },
   {
     path: '',
-    // canActivate: [authGuard],
+    canActivate: [authGuard],
     component: AppShell,
     children: [
       {

--- a/frontend/app/src/app/core/guards/auth-flow-guard.spec.ts
+++ b/frontend/app/src/app/core/guards/auth-flow-guard.spec.ts
@@ -1,0 +1,70 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+
+import { authFlowGuard } from './auth-flow-guard';
+
+describe('authFlowGuard', () => {
+  const loginTree = {};
+  let router: {
+    getCurrentNavigation: ReturnType<typeof vi.fn>;
+    createUrlTree: ReturnType<typeof vi.fn>;
+  };
+
+  const executeGuard = (path: string) =>
+    TestBed.runInInjectionContext(() =>
+      authFlowGuard(
+        { routeConfig: { path } } as ActivatedRouteSnapshot,
+        {} as RouterStateSnapshot,
+      ),
+    );
+
+  beforeEach(() => {
+    router = {
+      getCurrentNavigation: vi.fn(),
+      createUrlTree: vi.fn().mockReturnValue(loginTree),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: Router, useValue: router }],
+    });
+  });
+
+  it('allows register-success after a register submit navigation', () => {
+    router.getCurrentNavigation.mockReturnValue({
+      extras: { state: { fromRegisterSubmit: true } },
+    });
+
+    expect(executeGuard('register-success')).toBe(true);
+  });
+
+  it('redirects register-success without the required navigation state', () => {
+    router.getCurrentNavigation.mockReturnValue({ extras: {} });
+
+    expect(executeGuard('register-success')).toBe(loginTree);
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/login']);
+  });
+
+  it('allows forgot-password from the login link navigation', () => {
+    router.getCurrentNavigation.mockReturnValue({
+      extras: { state: { fromLoginLink: true } },
+    });
+
+    expect(executeGuard('forgot-password')).toBe(true);
+  });
+
+  it('allows forgot-password from the forgot-password-success navigation', () => {
+    router.getCurrentNavigation.mockReturnValue({
+      extras: { state: { fromForgotPasswordSuccess: true } },
+    });
+
+    expect(executeGuard('forgot-password')).toBe(true);
+  });
+
+  it('allows forgot-password-success after a successful forgot-password request', () => {
+    router.getCurrentNavigation.mockReturnValue({
+      extras: { state: { fromForgotPasswordSubmit: true } },
+    });
+
+    expect(executeGuard('forgot-password-success')).toBe(true);
+  });
+});

--- a/frontend/app/src/app/core/guards/auth-flow-guard.ts
+++ b/frontend/app/src/app/core/guards/auth-flow-guard.ts
@@ -1,0 +1,20 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+const ALLOWED_STATE_KEYS_BY_ROUTE: Record<string, string[]> = {
+  'register-success': ['fromRegisterSubmit'],
+  'forgot-password': ['fromLoginLink', 'fromForgotPasswordSuccess'],
+  'forgot-password-success': ['fromForgotPasswordSubmit'],
+};
+
+export const authFlowGuard: CanActivateFn = (route) => {
+  const router = inject(Router);
+  const stateKeys = ALLOWED_STATE_KEYS_BY_ROUTE[route.routeConfig?.path ?? ''];
+  const navigationState = router.getCurrentNavigation()?.extras.state;
+
+  if (stateKeys?.some((stateKey) => navigationState?.[stateKey] === true)) {
+    return true;
+  }
+
+  return router.createUrlTree(['/login']);
+};

--- a/frontend/app/src/app/core/guards/auth-guard.spec.ts
+++ b/frontend/app/src/app/core/guards/auth-guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { authGuard } from './auth-guard';
+
+describe('authGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/frontend/app/src/app/core/guards/auth-guard.ts
+++ b/frontend/app/src/app/core/guards/auth-guard.ts
@@ -1,0 +1,14 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '@core/services/auth.service';
+
+export const authGuard: CanActivateFn = (route, state) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (!authService.isAuthenticated()) {
+    return router.createUrlTree(['/login']);
+  }
+
+  return true;
+};

--- a/frontend/app/src/app/core/guards/mail-link-guard.spec.ts
+++ b/frontend/app/src/app/core/guards/mail-link-guard.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ActivatedRouteSnapshot,
+  Router,
+  RouterStateSnapshot,
+  convertToParamMap,
+} from '@angular/router';
+
+import { mailLinkGuard } from './mail-link-guard';
+
+describe('mailLinkGuard', () => {
+  const loginTree = {};
+  let router: { createUrlTree: ReturnType<typeof vi.fn> };
+
+  const executeGuard = (queryParams: Record<string, string>) =>
+    TestBed.runInInjectionContext(() =>
+      mailLinkGuard(
+        { queryParamMap: convertToParamMap(queryParams) } as ActivatedRouteSnapshot,
+        {} as RouterStateSnapshot,
+      ),
+    );
+
+  beforeEach(() => {
+    router = {
+      createUrlTree: vi.fn().mockReturnValue(loginTree),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: Router, useValue: router }],
+    });
+  });
+
+  it('allows mail links with uid and token', () => {
+    expect(executeGuard({ uid: 'abc', token: 'xyz' })).toBe(true);
+  });
+
+  it('redirects routes without complete mail link parameters', () => {
+    expect(executeGuard({ uid: 'abc' })).toBe(loginTree);
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/login']);
+  });
+});

--- a/frontend/app/src/app/core/guards/mail-link-guard.ts
+++ b/frontend/app/src/app/core/guards/mail-link-guard.ts
@@ -1,0 +1,14 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+export const mailLinkGuard: CanActivateFn = (route) => {
+  const router = inject(Router);
+  const uid = route.queryParamMap.get('uid');
+  const token = route.queryParamMap.get('token');
+
+  if (uid && token) {
+    return true;
+  }
+
+  return router.createUrlTree(['/login']);
+};

--- a/frontend/app/src/app/core/layout/app-shell/app-shell.html
+++ b/frontend/app/src/app/core/layout/app-shell/app-shell.html
@@ -38,7 +38,7 @@
             <mat-divider class="nav__divider"></mat-divider>
           }
           @for (item of section.items; track item.label) {
-            <button mat-menu-item class="standard-button">
+            <button mat-menu-item class="standard-button" (click)="onMenuClick(item)">
               <mat-icon>{{ item.icon }}</mat-icon>
               <span>{{ item.label }}</span>
             </button>

--- a/frontend/app/src/app/core/layout/app-shell/app-shell.ts
+++ b/frontend/app/src/app/core/layout/app-shell/app-shell.ts
@@ -9,6 +9,8 @@ import { MatInputModule } from '@angular/material/input';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatDividerModule } from '@angular/material/divider';
 import { ThemeService } from '@core/services/theme.service';
+import { AuthService } from '@core/services/auth.service';
+import { Router } from '@angular/router';
 
 type Theme = 'light' | 'dark';
 
@@ -35,24 +37,24 @@ type Theme = 'light' | 'dark';
 export class AppShell {
   protected readonly themeService = inject(ThemeService);
   protected readonly sidenavExpanded = signal(false);
+  private readonly authService = inject(AuthService);
 
-  /* private currentTheme: Theme = 'light';
-  isDark: boolean | null = null; */
+  constructor(private router: Router) {}
 
   menuSections = [
     {
       items: [
-        { label: 'Profil', icon: 'account_circle' },
-        { label: 'Einstellungen', icon: 'settings' },
+        { label: 'Profil', icon: 'account_circle', action: 'openProfile' },
+        { label: 'Einstellungen', icon: 'settings', action: 'openSettings' },
       ],
     },
     {
       divider: true,
-      items: [{ label: 'Über TalkCore', icon: 'info' }],
+      items: [{ label: 'Über TalkCore', icon: 'info', action: 'openInfo' }],
     },
     {
       divider: true,
-      items: [{ label: 'Logout', icon: 'logout' }],
+      items: [{ label: 'Logout', icon: 'logout', action: 'logout' }],
     },
   ];
 
@@ -75,5 +77,27 @@ export class AppShell {
 
   toggleSidenav(): void {
     this.sidenavExpanded.update((expanded) => !expanded);
+  }
+
+  onMenuClick(item: any): void {
+    switch (item.action) {
+      case 'openProfile':
+        // this.openProfile();
+        break;
+      case 'openSettings':
+        // this.openSettings();
+        break;
+      case 'openInfo':
+        // this.openInfo();
+        break;
+      case 'logout':
+        this.logout();
+        break;
+    }
+  }
+
+  logout(): void {
+    this.authService.logout();
+    this.router.navigate(['/login']);
   }
 }

--- a/frontend/app/src/app/core/layout/app-shell/app-shell.ts
+++ b/frontend/app/src/app/core/layout/app-shell/app-shell.ts
@@ -97,7 +97,16 @@ export class AppShell {
   }
 
   logout(): void {
-    this.authService.logout();
-    this.router.navigate(['/login']);
+    this.authService.logout().subscribe({
+      next: () => {
+        this.authService.clearLocalData();
+        this.router.navigate(['/login']);
+      },
+      error: () => {
+        // fallback: trotzdem lokal logouten
+        this.authService.clearLocalData();
+        this.router.navigate(['/login']);
+      },
+    });
   }
 }

--- a/frontend/app/src/app/core/layout/auth-shell/auth-shell.html
+++ b/frontend/app/src/app/core/layout/auth-shell/auth-shell.html
@@ -20,7 +20,7 @@
     </div>
   </mat-toolbar>
   <div class="main-content">
-    <main class="main-content__inner center-div">
+    <main class="main-content__inner main-content__center">
       <mat-card class="auth-card">
         <router-outlet></router-outlet>
       </mat-card>

--- a/frontend/app/src/app/core/models/auth.models.ts
+++ b/frontend/app/src/app/core/models/auth.models.ts
@@ -38,6 +38,11 @@ export interface ConfirmPasswordResetRequest {
   password_confirm: string;
 }
 
+export interface ActivateAccountRequest {
+  uid: string;
+  token: string;
+}
+
 export interface DetailResponse {
   detail: string;
 }

--- a/frontend/app/src/app/core/models/auth.models.ts
+++ b/frontend/app/src/app/core/models/auth.models.ts
@@ -19,3 +19,14 @@ export interface LoginResponse {
   refresh: string;
   user: User;
 }
+
+export interface RegisterRequest {
+  display_name: string;
+  email: string;
+  password: string;
+  password_confirm: string;
+}
+
+export interface RegisterResponse {
+  detail: string;
+}

--- a/frontend/app/src/app/core/models/auth.models.ts
+++ b/frontend/app/src/app/core/models/auth.models.ts
@@ -30,3 +30,14 @@ export interface RegisterRequest {
 export interface RegisterResponse {
   detail: string;
 }
+
+export interface ConfirmPasswordResetRequest {
+  uid: string;
+  token: string;
+  password: string;
+  password_confirm: string;
+}
+
+export interface DetailResponse {
+  detail: string;
+}

--- a/frontend/app/src/app/core/services/auth.service.spec.ts
+++ b/frontend/app/src/app/core/services/auth.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { AuthService } from './auth.service';
 
@@ -6,7 +7,9 @@ describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient()],
+    });
     service = TestBed.inject(AuthService);
   });
 

--- a/frontend/app/src/app/core/services/auth.service.ts
+++ b/frontend/app/src/app/core/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, tap } from 'rxjs';
+import { Observable, tap, of } from 'rxjs';
 
 import { LoginRequest, LoginResponse, User } from '../models/auth.models';
 
@@ -23,7 +23,20 @@ export class AuthService {
     );
   }
 
-  logout(): void {
+  logout(): Observable<void> {
+    const refreshToken = localStorage.getItem(this.REFRESH_TOKEN_KEY);
+
+    if (!refreshToken) {
+      this.clearLocalData();
+      return of(void 0);
+    }
+
+    return this.http.post<void>(`${this.apiUrl}/logout/`, {
+      refresh: refreshToken,
+    });
+  }
+
+  clearLocalData(): void {
     localStorage.removeItem(this.ACCESS_TOKEN_KEY);
     localStorage.removeItem(this.REFRESH_TOKEN_KEY);
     localStorage.removeItem(this.USER_KEY);

--- a/frontend/app/src/app/core/services/auth.service.ts
+++ b/frontend/app/src/app/core/services/auth.service.ts
@@ -46,6 +46,10 @@ export class AuthService {
     });
   }
 
+  requestPasswordReset(email: string): Observable<void> {
+    return this.http.post<void>(`${this.apiUrl}/reset-password/`, { email });
+  }
+
   clearLocalData(): void {
     localStorage.removeItem(this.ACCESS_TOKEN_KEY);
     localStorage.removeItem(this.REFRESH_TOKEN_KEY);

--- a/frontend/app/src/app/core/services/auth.service.ts
+++ b/frontend/app/src/app/core/services/auth.service.ts
@@ -2,7 +2,13 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, tap, of } from 'rxjs';
 
-import { LoginRequest, LoginResponse, User } from '../models/auth.models';
+import {
+  LoginRequest,
+  LoginResponse,
+  RegisterRequest,
+  RegisterResponse,
+  User,
+} from '../models/auth.models';
 
 @Injectable({
   providedIn: 'root',
@@ -21,6 +27,10 @@ export class AuthService {
         this.setSession(response);
       }),
     );
+  }
+
+  register(payload: RegisterRequest): Observable<RegisterResponse> {
+    return this.http.post<RegisterResponse>(`${this.apiUrl}/register/`, payload);
   }
 
   logout(): Observable<void> {

--- a/frontend/app/src/app/core/services/auth.service.ts
+++ b/frontend/app/src/app/core/services/auth.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, tap, of } from 'rxjs';
 
 import {
+  ActivateAccountRequest,
   ConfirmPasswordResetRequest,
   DetailResponse,
   LoginRequest,
@@ -50,6 +51,15 @@ export class AuthService {
 
   requestPasswordReset(email: string): Observable<void> {
     return this.http.post<void>(`${this.apiUrl}/reset-password/`, { email });
+  }
+
+  activateAccount(payload: ActivateAccountRequest): Observable<DetailResponse> {
+    return this.http.get<DetailResponse>(`${this.apiUrl}/activate/`, {
+      params: {
+        uid: payload.uid,
+        token: payload.token,
+      },
+    });
   }
 
   confirmPasswordReset(payload: ConfirmPasswordResetRequest): Observable<DetailResponse> {

--- a/frontend/app/src/app/core/services/auth.service.ts
+++ b/frontend/app/src/app/core/services/auth.service.ts
@@ -3,6 +3,8 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, tap, of } from 'rxjs';
 
 import {
+  ConfirmPasswordResetRequest,
+  DetailResponse,
   LoginRequest,
   LoginResponse,
   RegisterRequest,
@@ -48,6 +50,10 @@ export class AuthService {
 
   requestPasswordReset(email: string): Observable<void> {
     return this.http.post<void>(`${this.apiUrl}/reset-password/`, { email });
+  }
+
+  confirmPasswordReset(payload: ConfirmPasswordResetRequest): Observable<DetailResponse> {
+    return this.http.post<DetailResponse>(`${this.apiUrl}/confirm-password/`, payload);
   }
 
   clearLocalData(): void {

--- a/frontend/app/src/app/features/auth/auth.routes.ts
+++ b/frontend/app/src/app/features/auth/auth.routes.ts
@@ -1,5 +1,7 @@
 import { Routes } from '@angular/router';
+import { authFlowGuard } from '@core/guards/auth-flow-guard';
 import { guestGuard } from '@core/guards/guest-guard';
+import { mailLinkGuard } from '@core/guards/mail-link-guard';
 
 export const AUTH_ROUTES: Routes = [
   {
@@ -19,7 +21,7 @@ export const AUTH_ROUTES: Routes = [
   },
   {
     path: 'register-success',
-    canActivate: [guestGuard],
+    canActivate: [guestGuard, authFlowGuard],
     loadComponent: () =>
       import('./pages/register-success-page/register-success-page').then(
         (m) => m.RegisterSuccessPage,
@@ -27,18 +29,18 @@ export const AUTH_ROUTES: Routes = [
   },
   {
     path: 'activate',
-    canActivate: [guestGuard],
+    canActivate: [guestGuard, mailLinkGuard],
     loadComponent: () => import('./pages/activate-page/activate-page').then((m) => m.ActivatePage),
   },
   {
     path: 'forgot-password',
-    canActivate: [guestGuard],
+    canActivate: [guestGuard, authFlowGuard],
     loadComponent: () =>
       import('./pages/forgot-password-page/forgot-password-page').then((m) => m.ForgotPasswordPage),
   },
   {
     path: 'forgot-password-success',
-    canActivate: [guestGuard],
+    canActivate: [guestGuard, authFlowGuard],
     loadComponent: () =>
       import('./pages/forgot-password-success-page/forgot-password-success-page').then(
         (m) => m.ForgotPasswordSuccessPage,
@@ -46,7 +48,7 @@ export const AUTH_ROUTES: Routes = [
   },
   {
     path: 'reset-password',
-    canActivate: [guestGuard],
+    canActivate: [guestGuard, mailLinkGuard],
     loadComponent: () =>
       import('./pages/reset-password-page/reset-password-page').then((m) => m.ResetPasswordPage),
   },

--- a/frontend/app/src/app/features/auth/auth.routes.ts
+++ b/frontend/app/src/app/features/auth/auth.routes.ts
@@ -20,11 +20,34 @@ export const AUTH_ROUTES: Routes = [
   {
     path: 'register-success',
     canActivate: [guestGuard],
-    loadComponent: () => import('./pages/register-success-page/register-success-page').then((m) => m.RegisterSuccessPage),
+    loadComponent: () =>
+      import('./pages/register-success-page/register-success-page').then(
+        (m) => m.RegisterSuccessPage,
+      ),
   },
   {
     path: 'activate',
     canActivate: [guestGuard],
     loadComponent: () => import('./pages/activate-page/activate-page').then((m) => m.ActivatePage),
+  },
+  {
+    path: 'forgot-password',
+    canActivate: [guestGuard],
+    loadComponent: () =>
+      import('./pages/forgot-password-page/forgot-password-page').then((m) => m.ForgotPasswordPage),
+  },
+  {
+    path: 'forgot-password-success',
+    canActivate: [guestGuard],
+    loadComponent: () =>
+      import('./pages/forgot-password-success-page/forgot-password-success-page').then(
+        (m) => m.ForgotPasswordSuccessPage,
+      ),
+  },
+  {
+    path: 'reset-password',
+    canActivate: [guestGuard],
+    loadComponent: () =>
+      import('./pages/reset-password-page/reset-password-page').then((m) => m.ResetPasswordPage),
   },
 ];

--- a/frontend/app/src/app/features/auth/auth.routes.ts
+++ b/frontend/app/src/app/features/auth/auth.routes.ts
@@ -10,19 +10,21 @@ export const AUTH_ROUTES: Routes = [
   {
     path: 'login',
     canActivate: [guestGuard],
-    loadComponent: () =>
-      import('./pages/login-page/login-page').then((m) => m.LoginPage),
+    loadComponent: () => import('./pages/login-page/login-page').then((m) => m.LoginPage),
   },
   {
     path: 'register',
     canActivate: [guestGuard],
-    loadComponent: () =>
-      import('./pages/register-page/register-page').then((m) => m.RegisterPage),
+    loadComponent: () => import('./pages/register-page/register-page').then((m) => m.RegisterPage),
+  },
+  {
+    path: 'register-success',
+    canActivate: [guestGuard],
+    loadComponent: () => import('./pages/register-success-page/register-success-page').then((m) => m.RegisterSuccessPage),
   },
   {
     path: 'activate',
     canActivate: [guestGuard],
-    loadComponent: () =>
-      import('./pages/activate-page/activate-page').then((m) => m.ActivatePage),
+    loadComponent: () => import('./pages/activate-page/activate-page').then((m) => m.ActivatePage),
   },
 ];

--- a/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.html
+++ b/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.html
@@ -1,12 +1,12 @@
 <section class="auth-form-layout">
-  <div class="auth-form-layout__header">
+  <header class="auth-form-layout__header">
     <h2 class="auth-form-layout__title">{{ title() }}</h2>
     <p class="auth-form-layout__subtitle">{{ subtitle() }}</p>
-  </div>
+  </header>
 
   <ng-content select="[authFormContent]"></ng-content>
 
-  <div class="auth-form-layout__footer">
+  <footer class="auth-form-layout__footer">
     <ng-content select="[authFormFooter]"></ng-content>
-  </div>
+  </footer>
 </section>

--- a/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.html
+++ b/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.html
@@ -1,0 +1,12 @@
+<section class="auth-form-layout">
+  <div class="auth-form-layout__header">
+    <h2 class="auth-form-layout__title">{{ title() }}</h2>
+    <p class="auth-form-layout__subtitle">{{ subtitle() }}</p>
+  </div>
+
+  <ng-content select="[authFormContent]"></ng-content>
+
+  <div class="auth-form-layout__footer">
+    <ng-content select="[authFormFooter]"></ng-content>
+  </div>
+</section>

--- a/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.scss
+++ b/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.scss
@@ -1,6 +1,6 @@
 @use '@angular/material' as mat;
 
-.login-page {
+.auth-form-layout {
   display: flex;
   flex-direction: column;
   gap: 2rem;
@@ -9,32 +9,32 @@
   color: var(--auth-body-text);
 }
 
-.login-page__header {
+.auth-form-layout__header {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
-.login-page__title {
+.auth-form-layout__title {
   margin: 0;
   color: var(--auth-title-text);
   font-size: clamp(1.75rem, 2.6vw, 2.15rem);
   line-height: 1.15;
 }
 
-.login-page__subtitle {
+.auth-form-layout__subtitle {
   margin: 0;
   color: var(--auth-muted-text);
   line-height: 1.5;
 }
 
-.login-form {
+:host ::ng-deep .auth-form {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.login-form__field {
+:host ::ng-deep .auth-form__field {
   width: 100%;
 
   @include mat.form-field-overrides(
@@ -57,17 +57,17 @@
   );
 }
 
-.login-form__field ::ng-deep .mat-mdc-text-field-wrapper {
+:host ::ng-deep .auth-form__field .mat-mdc-text-field-wrapper {
   background: var(--auth-form-field-bg);
   border-radius: 1rem;
 }
 
-.login-form__field ::ng-deep .mat-mdc-form-field-icon-prefix {
+:host ::ng-deep .auth-form__field .mat-mdc-form-field-icon-prefix {
   padding-right: 0.75rem;
   color: var(--auth-muted-text);
 }
 
-.login-form__options {
+:host ::ng-deep .auth-form__options {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -75,15 +75,17 @@
   flex-wrap: wrap;
   color: var(--auth-muted-text);
 
-  @include mat.checkbox-overrides((
-    selected-icon-color: var(--auth-form-field-focus),
-    selected-hover-icon-color: var(--auth-checkbox-hover),
-    selected-focus-icon-color: var(--auth-checkbox-focus),
-  ))
+  @include mat.checkbox-overrides(
+    (
+      selected-icon-color: var(--auth-form-field-focus),
+      selected-hover-icon-color: var(--auth-checkbox-hover),
+      selected-focus-icon-color: var(--auth-checkbox-focus),
+    )
+  );
 }
 
-.login-form__aux-link,
-.login-page__footer a {
+:host ::ng-deep .auth-form__aux-link,
+.auth-form-layout__footer ::ng-deep a {
   color: var(--auth-link-text);
   font-weight: 600;
   transition:
@@ -91,22 +93,31 @@
     opacity 0.2s ease;
 }
 
-.login-form__aux-link:hover,
-.login-page__footer a:hover {
+:host ::ng-deep .auth-form__aux-link:hover,
+.auth-form-layout__footer ::ng-deep a:hover {
   color: var(--auth-link-hover-text);
 }
 
-.login-form__error {
+:host ::ng-deep .auth-form__message {
   margin: 0;
   padding: 0.875rem 1rem;
-  border: 1px solid var(--auth-error-border);
   border-radius: 0.9rem;
-  background: var(--auth-error-bg);
-  color: var(--auth-error-text);
   font-size: 0.95rem;
 }
 
-.login-form__submit {
+:host ::ng-deep .auth-form__message--error {
+  border: 1px solid var(--auth-error-border);
+  background: var(--auth-error-bg);
+  color: var(--auth-error-text);
+}
+
+:host ::ng-deep .auth-form__message--success {
+  border: 1px solid var(--auth-form-field-focus);
+  background: color-mix(in srgb, var(--auth-form-field-focus) 12%, transparent);
+  color: var(--auth-title-text);
+}
+
+:host ::ng-deep .auth-form__submit {
   min-height: 3rem;
   margin-top: 0.25rem;
   border-radius: 999px;
@@ -125,16 +136,16 @@
   );
 }
 
-.login-form__submit:hover:not(:disabled) {
+:host ::ng-deep .auth-form__submit:hover:not(:disabled) {
   background: var(--auth-submit-hover-bg);
   transform: translateY(-1px);
 }
 
-.login-form__submit:disabled {
+:host ::ng-deep .auth-form__submit:disabled {
   opacity: 0.6;
 }
 
-.login-page__footer {
+.auth-form-layout__footer {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -145,17 +156,17 @@
 }
 
 @media (max-width: 600px) {
-  .login-page {
+  .auth-form-layout {
     gap: 1.5rem;
     padding: 1.25rem;
   }
 
-  .login-form__options {
+  :host ::ng-deep .auth-form__options {
     align-items: flex-start;
     flex-direction: column;
   }
 
-  .login-form__submit {
+  :host ::ng-deep .auth-form__submit {
     width: 100%;
   }
 }

--- a/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.scss
+++ b/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.scss
@@ -4,7 +4,6 @@
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  width: min(100%, 28rem);
   padding: clamp(1.5rem, 2vw, 2rem);
   color: var(--auth-body-text);
 }

--- a/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.scss
+++ b/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.scss
@@ -6,7 +6,7 @@
   gap: 2rem;
   padding: clamp(1.5rem, 2vw, 2rem);
   color: var(--auth-body-text);
-  max-width: 500px;
+  width: 500px;
 }
 
 .auth-form-layout__header {

--- a/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.scss
+++ b/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.scss
@@ -6,6 +6,7 @@
   gap: 2rem;
   padding: clamp(1.5rem, 2vw, 2rem);
   color: var(--auth-body-text);
+  max-width: 500px;
 }
 
 .auth-form-layout__header {

--- a/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.ts
+++ b/frontend/app/src/app/features/auth/components/auth-form-layout/auth-form-layout.ts
@@ -1,0 +1,11 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-auth-form-layout',
+  templateUrl: './auth-form-layout.html',
+  styleUrl: './auth-form-layout.scss',
+})
+export class AuthFormLayout {
+  title = input.required<string>();
+  subtitle = input.required<string>();
+}

--- a/frontend/app/src/app/features/auth/pages/activate-page/activate-page.html
+++ b/frontend/app/src/app/features/auth/pages/activate-page/activate-page.html
@@ -1,0 +1,1 @@
+<p>activate-page works!</p>

--- a/frontend/app/src/app/features/auth/pages/activate-page/activate-page.html
+++ b/frontend/app/src/app/features/auth/pages/activate-page/activate-page.html
@@ -1,1 +1,25 @@
-<p>activate-page works!</p>
+<app-auth-form-layout title="Konto aktivieren" subtitle="Wir prüfen deinen Aktivierungslink">
+  <main authFormContent>
+    @if (isActivating()) {
+      <p class="auth-form__message" role="status">Dein Konto wird aktiviert ...</p>
+    }
+
+    @if (errorMessage()) {
+      <p class="auth-form__message auth-form__message--error" role="alert">{{ errorMessage() }}</p>
+    }
+
+    @if (successMessage()) {
+      <p class="auth-form__message auth-form__message--success" role="status">
+        {{ successMessage() }}
+      </p>
+      <div class="auth-form__submit-container">
+        <a mat-flat-button routerLink="/login" class="auth-form__submit">Zum Login</a>
+      </div>
+    }
+  </main>
+
+  <ng-container authFormFooter>
+    <span>Schon aktiviert?</span>
+    <a routerLink="/login">Jetzt anmelden</a>
+  </ng-container>
+</app-auth-form-layout>

--- a/frontend/app/src/app/features/auth/pages/activate-page/activate-page.scss
+++ b/frontend/app/src/app/features/auth/pages/activate-page/activate-page.scss
@@ -1,0 +1,6 @@
+@import '@styles/_mixins.scss';
+
+.auth-form__submit-container {
+    @include d-flex();
+    margin-top: 1rem;
+}

--- a/frontend/app/src/app/features/auth/pages/activate-page/activate-page.spec.ts
+++ b/frontend/app/src/app/features/auth/pages/activate-page/activate-page.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
 
 import { ActivatePage } from './activate-page';
+import { AuthService } from '@core/services/auth.service';
 
 describe('ActivatePage', () => {
   let component: ActivatePage;
@@ -8,9 +11,17 @@ describe('ActivatePage', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ActivatePage]
-    })
-    .compileComponents();
+      imports: [ActivatePage],
+      providers: [
+        provideRouter([]),
+        {
+          provide: AuthService,
+          useValue: {
+            activateAccount: () => of({ detail: 'Account activated successfully.' }),
+          },
+        },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ActivatePage);
     component = fixture.componentInstance;

--- a/frontend/app/src/app/features/auth/pages/activate-page/activate-page.spec.ts
+++ b/frontend/app/src/app/features/auth/pages/activate-page/activate-page.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ActivatePage } from './activate-page';
+
+describe('ActivatePage', () => {
+  let component: ActivatePage;
+  let fixture: ComponentFixture<ActivatePage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ActivatePage]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ActivatePage);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/app/src/app/features/auth/pages/activate-page/activate-page.ts
+++ b/frontend/app/src/app/features/auth/pages/activate-page/activate-page.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-activate-page',
+  imports: [],
+  templateUrl: './activate-page.html',
+  styleUrl: './activate-page.scss',
+})
+export class ActivatePage {
+
+}

--- a/frontend/app/src/app/features/auth/pages/activate-page/activate-page.ts
+++ b/frontend/app/src/app/features/auth/pages/activate-page/activate-page.ts
@@ -1,11 +1,72 @@
-import { Component } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { AuthService } from '@core/services/auth.service';
+import { finalize } from 'rxjs';
+import { AuthFormLayout } from '../../components/auth-form-layout/auth-form-layout';
 
 @Component({
   selector: 'app-activate-page',
-  imports: [],
+  imports: [AuthFormLayout, RouterLink, MatButtonModule],
   templateUrl: './activate-page.html',
-  styleUrl: './activate-page.scss',
+  styleUrl: './activate-page.scss'
 })
 export class ActivatePage {
+  private readonly authService = inject(AuthService);
+  private readonly route = inject(ActivatedRoute);
 
+  private readonly uid = this.normalizeActivationParam(this.route.snapshot.queryParamMap.get('uid'));
+  private readonly token = this.normalizeActivationParam(
+    this.route.snapshot.queryParamMap.get('token'),
+  );
+
+  errorMessage = signal('');
+  successMessage = signal('');
+  isActivating = signal(false);
+
+  get hasActivationLink(): boolean {
+    return Boolean(this.uid && this.token);
+  }
+
+  constructor() {
+    if (!this.hasActivationLink) {
+      this.errorMessage.set(
+        'Der Aktivierungslink ist unvollständig. Bitte nutze den Link aus deiner E-Mail.',
+      );
+      return;
+    }
+
+    this.activateAccount();
+  }
+
+  private activateAccount(): void {
+    this.isActivating.set(true);
+
+    this.authService
+      .activateAccount({
+        uid: this.uid,
+        token: this.token,
+      })
+      .pipe(finalize(() => this.isActivating.set(false)))
+      .subscribe({
+        next: () => {
+          this.successMessage.set('Dein Konto wurde erfolgreich aktiviert.');
+        },
+        error: () => {
+          this.errorMessage.set(
+            'Dein Konto konnte nicht aktiviert werden. Der Link ist ungültig oder abgelaufen.',
+          );
+        },
+      });
+  }
+
+  private normalizeActivationParam(value: string | null): string {
+    const normalized = (value ?? '').replace(/\s+/g, '').replace(/=3D/gi, '=');
+
+    if (normalized.startsWith('3D')) {
+      return normalized.slice(2);
+    }
+
+    return normalized;
+  }
 }

--- a/frontend/app/src/app/features/auth/pages/forgot-password-page/forgot-password-page.html
+++ b/frontend/app/src/app/features/auth/pages/forgot-password-page/forgot-password-page.html
@@ -1,5 +1,5 @@
 <app-auth-form-layout title="Passwort zurücksetzen" subtitle="Bitte gib deine E-Mail-Adresse ein">
-  <div authFormContent class="register-success-page__content">
+  <main authFormContent>
     <p>
       Gib die E-Mail-Adresse ein, mit der du dich registriert hast. Wenn ein Konto mit dieser
       Adresse existiert, senden wir dir eine E-Mail mit einem Link zum Zurücksetzen deines
@@ -17,13 +17,18 @@
           required
           email
           [(ngModel)]="email"
-          
           #emailModel="ngModel"
         />
         @if (emailModel.invalid && emailModel.touched) {
           <mat-error>Bitte gib eine gültige E-Mail-Adresse ein.</mat-error>
         }
       </mat-form-field>
+
+      @if (errorMessage()) {
+        <p class="auth-form__message auth-form__message--error" role="alert">
+          {{ errorMessage() }}
+        </p>
+      }
 
       <button
         mat-flat-button
@@ -34,7 +39,7 @@
         Link zum Zurücksetzen senden
       </button>
     </form>
-  </div>
+  </main>
   <ng-container authFormFooter>
     <a routerLink="/login">Zum Login</a>
   </ng-container>

--- a/frontend/app/src/app/features/auth/pages/forgot-password-page/forgot-password-page.html
+++ b/frontend/app/src/app/features/auth/pages/forgot-password-page/forgot-password-page.html
@@ -1,0 +1,41 @@
+<app-auth-form-layout title="Passwort zurücksetzen" subtitle="Bitte gib deine E-Mail-Adresse ein">
+  <div authFormContent class="register-success-page__content">
+    <p>
+      Gib die E-Mail-Adresse ein, mit der du dich registriert hast. Wenn ein Konto mit dieser
+      Adresse existiert, senden wir dir eine E-Mail mit einem Link zum Zurücksetzen deines
+      Passworts.
+    </p>
+    <form authFormContent class="auth-form" (ngSubmit)="onSubmit()" #loginForm="ngForm">
+      <mat-form-field appearance="outline" class="auth-form__field">
+        <mat-label>E-Mail-Adresse</mat-label>
+        <mat-icon matPrefix fontSet="material-symbols-rounded">mail</mat-icon>
+        <input
+          matInput
+          type="email"
+          name="email"
+          autocomplete="email"
+          required
+          email
+          [(ngModel)]="email"
+          
+          #emailModel="ngModel"
+        />
+        @if (emailModel.invalid && emailModel.touched) {
+          <mat-error>Bitte gib eine gültige E-Mail-Adresse ein.</mat-error>
+        }
+      </mat-form-field>
+
+      <button
+        mat-flat-button
+        type="submit"
+        class="auth-form__submit"
+        [disabled]="loginForm.invalid"
+      >
+        Link zum Zurücksetzen senden
+      </button>
+    </form>
+  </div>
+  <ng-container authFormFooter>
+    <a routerLink="/login">Zum Login</a>
+  </ng-container>
+</app-auth-form-layout>

--- a/frontend/app/src/app/features/auth/pages/forgot-password-page/forgot-password-page.spec.ts
+++ b/frontend/app/src/app/features/auth/pages/forgot-password-page/forgot-password-page.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ForgotPasswordPage } from './forgot-password-page';
+
+describe('ForgotPasswordPage', () => {
+  let component: ForgotPasswordPage;
+  let fixture: ComponentFixture<ForgotPasswordPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ForgotPasswordPage]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ForgotPasswordPage);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/app/src/app/features/auth/pages/forgot-password-page/forgot-password-page.ts
+++ b/frontend/app/src/app/features/auth/pages/forgot-password-page/forgot-password-page.ts
@@ -22,7 +22,6 @@ import { AuthService } from '@core/services/auth.service';
     AuthFormLayout,
   ],
   templateUrl: './forgot-password-page.html',
-  styleUrl: './forgot-password-page.scss',
 })
 export class ForgotPasswordPage {
   private readonly authService = inject(AuthService);
@@ -31,12 +30,22 @@ export class ForgotPasswordPage {
   email = '';
   errorMessage = signal('');
 
+  ngOnInit(): void {
+    const emailFromState = history.state.email;
+
+    if (emailFromState) {
+      this.email = emailFromState;
+    }
+  }
+
   onSubmit(): void {
     this.errorMessage.set('');
 
     this.authService.requestPasswordReset(this.email).subscribe({
       next: () => {
-        this.router.navigate(['/forgot-password-success']);
+        this.router.navigate(['/forgot-password-success'], {
+          state: { email: this.email },
+        });
       },
       error: () => {
         this.errorMessage.set(

--- a/frontend/app/src/app/features/auth/pages/forgot-password-page/forgot-password-page.ts
+++ b/frontend/app/src/app/features/auth/pages/forgot-password-page/forgot-password-page.ts
@@ -1,0 +1,48 @@
+import { Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { AuthFormLayout } from '../../components/auth-form-layout/auth-form-layout';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { AuthService } from '@core/services/auth.service';
+
+@Component({
+  selector: 'app-forgot-password-page',
+  imports: [
+    FormsModule,
+    RouterLink,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    AuthFormLayout,
+  ],
+  templateUrl: './forgot-password-page.html',
+  styleUrl: './forgot-password-page.scss',
+})
+export class ForgotPasswordPage {
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+
+  email = '';
+  errorMessage = signal('');
+
+  onSubmit(): void {
+    this.errorMessage.set('');
+
+    this.authService.requestPasswordReset(this.email).subscribe({
+      next: () => {
+        this.router.navigate(['/forgot-password-success']);
+      },
+      error: () => {
+        this.errorMessage.set(
+          'Die Anfrage konnte nicht verarbeitet werden. Bitte versuche es später erneut.',
+        );
+      },
+    });
+  }
+}

--- a/frontend/app/src/app/features/auth/pages/forgot-password-page/forgot-password-page.ts
+++ b/frontend/app/src/app/features/auth/pages/forgot-password-page/forgot-password-page.ts
@@ -31,7 +31,7 @@ export class ForgotPasswordPage {
   errorMessage = signal('');
 
   ngOnInit(): void {
-    const emailFromState = history.state.email;
+    const emailFromState = history.state?.email;
 
     if (emailFromState) {
       this.email = emailFromState;
@@ -44,7 +44,7 @@ export class ForgotPasswordPage {
     this.authService.requestPasswordReset(this.email).subscribe({
       next: () => {
         this.router.navigate(['/forgot-password-success'], {
-          state: { email: this.email },
+          state: { email: this.email, fromForgotPasswordSubmit: true },
         });
       },
       error: () => {

--- a/frontend/app/src/app/features/auth/pages/forgot-password-success-page/forgot-password-success-page.html
+++ b/frontend/app/src/app/features/auth/pages/forgot-password-success-page/forgot-password-success-page.html
@@ -1,0 +1,19 @@
+<app-auth-form-layout title="E-Mail gesendet" subtitle="Bitte überprüfe dein Postfach">
+  <main authFormContent>
+    <p>
+      Wenn ein Konto mit dieser E-Mail-Adresse existiert, haben wir dir eine E-Mail mit einem Link
+      zum Zurücksetzen deines Passworts gesendet. Bitte öffne dein E-Mail-Postfach und folge den
+      Anweisungen in der Nachricht.
+    </p>
+    <p>
+      Falls du keine E-Mail erhalten hast, überprüfe bitte auch deinen Spam-Ordner oder versuche es
+      erneut.
+    </p>
+</main>
+  <ng-container authFormFooter>
+    <section class="footer-link-container">
+      <a routerLink="/login">Zurück zum Login</a>
+      <a routerLink="/forgot-password" [state]="{ email: email }">E-Mail erneut senden</a>
+    </section>
+  </ng-container>
+</app-auth-form-layout>

--- a/frontend/app/src/app/features/auth/pages/forgot-password-success-page/forgot-password-success-page.html
+++ b/frontend/app/src/app/features/auth/pages/forgot-password-success-page/forgot-password-success-page.html
@@ -13,7 +13,12 @@
   <ng-container authFormFooter>
     <section class="footer-link-container">
       <a routerLink="/login">Zurück zum Login</a>
-      <a routerLink="/forgot-password" [state]="{ email: email }">E-Mail erneut senden</a>
+      <a
+        routerLink="/forgot-password"
+        [state]="{ fromForgotPasswordSuccess: true, email: email }"
+      >
+        E-Mail erneut senden
+      </a>
     </section>
   </ng-container>
 </app-auth-form-layout>

--- a/frontend/app/src/app/features/auth/pages/forgot-password-success-page/forgot-password-success-page.scss
+++ b/frontend/app/src/app/features/auth/pages/forgot-password-success-page/forgot-password-success-page.scss
@@ -1,0 +1,6 @@
+@import '@styles/_mixins.scss';
+
+.footer-link-container {
+  @include d-flex($justify: space-between);
+  width: 100%;
+}

--- a/frontend/app/src/app/features/auth/pages/forgot-password-success-page/forgot-password-success-page.spec.ts
+++ b/frontend/app/src/app/features/auth/pages/forgot-password-success-page/forgot-password-success-page.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ForgotPasswordSuccessPage } from './forgot-password-success-page';
+
+describe('ForgotPasswordSuccessPage', () => {
+  let component: ForgotPasswordSuccessPage;
+  let fixture: ComponentFixture<ForgotPasswordSuccessPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ForgotPasswordSuccessPage]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ForgotPasswordSuccessPage);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/app/src/app/features/auth/pages/forgot-password-success-page/forgot-password-success-page.ts
+++ b/frontend/app/src/app/features/auth/pages/forgot-password-success-page/forgot-password-success-page.ts
@@ -9,5 +9,5 @@ import { AuthFormLayout } from '../../components/auth-form-layout/auth-form-layo
   styleUrl: './forgot-password-success-page.scss',
 })
 export class ForgotPasswordSuccessPage {
-  email = history.state.email ?? '';
+  email = history.state?.email ?? '';
 }

--- a/frontend/app/src/app/features/auth/pages/forgot-password-success-page/forgot-password-success-page.ts
+++ b/frontend/app/src/app/features/auth/pages/forgot-password-success-page/forgot-password-success-page.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { AuthFormLayout } from '../../components/auth-form-layout/auth-form-layout';
+
+@Component({
+  selector: 'app-forgot-password-success-page',
+  imports: [AuthFormLayout, RouterLink],
+  templateUrl: './forgot-password-success-page.html',
+  styleUrl: './forgot-password-success-page.scss',
+})
+export class ForgotPasswordSuccessPage {
+  email = history.state.email ?? '';
+}

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.html
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.html
@@ -1,0 +1,1 @@
+<p>login-page works!</p>

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.html
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.html
@@ -1,9 +1,7 @@
 <section class="login-page">
   <div class="login-page__header">
     <h2 class="login-page__title">Login</h2>
-    <p class="login-page__subtitle">
-      Melde dich mit deiner E-Mail-Adresse und deinem Passwort an.
-    </p>
+    <p class="login-page__subtitle">Melde dich mit deiner E-Mail-Adresse und deinem Passwort an.</p>
   </div>
 
   <form class="login-form" (ngSubmit)="onSubmit()" #loginForm="ngForm">
@@ -19,7 +17,11 @@
         email
         [(ngModel)]="email"
         (ngModelChange)="onEmailChange($event)"
+        #emailModel="ngModel"
       />
+      @if (emailModel.invalid && emailModel.touched) {
+        <mat-error>Bitte gib eine gültige E-Mail-Adresse ein.</mat-error>
+      }
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="login-form__field">
@@ -32,7 +34,11 @@
         autocomplete="current-password"
         required
         [(ngModel)]="password"
+        #passwordModel="ngModel"
       />
+      @if (passwordModel.touched) {
+        <mat-error>Bitte gib dein Passwort ein.</mat-error>
+      }
     </mat-form-field>
 
     <div class="login-form__options">
@@ -44,27 +50,20 @@
         E-Mail-Adresse merken
       </mat-checkbox>
 
-      <a routerLink="/auth/reset-password" class="login-form__aux-link">
-        Passwort vergessen
-      </a>
+      <a routerLink="/reset-password" class="login-form__aux-link"> Passwort vergessen </a>
     </div>
 
-    @if (errorMessage) {
-      <p class="login-form__error" role="alert">{{ errorMessage }}</p>
+    @if (errorMessage()) {
+      <p class="login-form__error" role="alert">{{ errorMessage() }}</p>
     }
 
-    <button
-      mat-flat-button
-      type="submit"
-      class="login-form__submit"
-      [disabled]="loginForm.invalid"
-    >
+    <button mat-flat-button type="submit" class="login-form__submit" [disabled]="loginForm.invalid">
       Anmelden
     </button>
   </form>
 
   <div class="login-page__footer">
     <span>Noch kein Konto?</span>
-    <a routerLink="/auth/register">Jetzt registrieren</a>
+    <a routerLink="/register">Jetzt registrieren</a>
   </div>
 </section>

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.html
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.html
@@ -48,7 +48,7 @@
         E-Mail-Adresse merken
       </mat-checkbox>
 
-      <a routerLink="/reset-password" class="auth-form__aux-link"> Passwort vergessen </a>
+      <a routerLink="/forgot-password" class="auth-form__aux-link"> Passwort vergessen </a>
     </div>
 
     @if (errorMessage()) {

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.html
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.html
@@ -1,6 +1,5 @@
 <section class="login-page">
   <div class="login-page__header">
-    <p class="login-page__eyebrow">Willkommen zurück</p>
     <h2 class="login-page__title">Login</h2>
     <p class="login-page__subtitle">
       Melde dich mit deiner E-Mail-Adresse und deinem Passwort an.

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.html
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.html
@@ -48,7 +48,13 @@
         E-Mail-Adresse merken
       </mat-checkbox>
 
-      <a routerLink="/forgot-password" class="auth-form__aux-link"> Passwort vergessen </a>
+      <a
+        routerLink="/forgot-password"
+        [state]="{ fromLoginLink: true }"
+        class="auth-form__aux-link"
+      >
+        Passwort vergessen
+      </a>
     </div>
 
     @if (errorMessage()) {

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.html
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.html
@@ -1,11 +1,9 @@
-<section class="login-page">
-  <div class="login-page__header">
-    <h2 class="login-page__title">Login</h2>
-    <p class="login-page__subtitle">Melde dich mit deiner E-Mail-Adresse und deinem Passwort an.</p>
-  </div>
-
-  <form class="login-form" (ngSubmit)="onSubmit()" #loginForm="ngForm">
-    <mat-form-field appearance="outline" class="login-form__field">
+<app-auth-form-layout
+  title="Login"
+  subtitle="Melde dich mit deiner E-Mail-Adresse und deinem Passwort an."
+>
+  <form authFormContent class="auth-form" (ngSubmit)="onSubmit()" #loginForm="ngForm">
+    <mat-form-field appearance="outline" class="auth-form__field">
       <mat-label>E-Mail-Adresse</mat-label>
       <mat-icon matPrefix fontSet="material-symbols-rounded">mail</mat-icon>
       <input
@@ -24,7 +22,7 @@
       }
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="login-form__field">
+    <mat-form-field appearance="outline" class="auth-form__field">
       <mat-label>Passwort</mat-label>
       <mat-icon matPrefix fontSet="material-symbols-rounded">lock</mat-icon>
       <input
@@ -41,7 +39,7 @@
       }
     </mat-form-field>
 
-    <div class="login-form__options">
+    <div class="auth-form__options">
       <mat-checkbox
         name="rememberEmail"
         [(ngModel)]="rememberEmail"
@@ -50,20 +48,20 @@
         E-Mail-Adresse merken
       </mat-checkbox>
 
-      <a routerLink="/reset-password" class="login-form__aux-link"> Passwort vergessen </a>
+      <a routerLink="/reset-password" class="auth-form__aux-link"> Passwort vergessen </a>
     </div>
 
     @if (errorMessage()) {
-      <p class="login-form__error" role="alert">{{ errorMessage() }}</p>
+      <p class="auth-form__message auth-form__message--error" role="alert">{{ errorMessage() }}</p>
     }
 
-    <button mat-flat-button type="submit" class="login-form__submit" [disabled]="loginForm.invalid">
+    <button mat-flat-button type="submit" class="auth-form__submit" [disabled]="loginForm.invalid">
       Anmelden
     </button>
   </form>
 
-  <div class="login-page__footer">
+  <ng-container authFormFooter>
     <span>Noch kein Konto?</span>
     <a routerLink="/register">Jetzt registrieren</a>
-  </div>
-</section>
+  </ng-container>
+</app-auth-form-layout>

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.html
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.html
@@ -1,1 +1,71 @@
-<p>login-page works!</p>
+<section class="login-page">
+  <div class="login-page__header">
+    <p class="login-page__eyebrow">Willkommen zurück</p>
+    <h2 class="login-page__title">Login</h2>
+    <p class="login-page__subtitle">
+      Melde dich mit deiner E-Mail-Adresse und deinem Passwort an.
+    </p>
+  </div>
+
+  <form class="login-form" (ngSubmit)="onSubmit()" #loginForm="ngForm">
+    <mat-form-field appearance="outline" class="login-form__field">
+      <mat-label>E-Mail-Adresse</mat-label>
+      <mat-icon matPrefix fontSet="material-symbols-rounded">mail</mat-icon>
+      <input
+        matInput
+        type="email"
+        name="email"
+        autocomplete="email"
+        required
+        email
+        [(ngModel)]="email"
+        (ngModelChange)="onEmailChange($event)"
+      />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="login-form__field">
+      <mat-label>Passwort</mat-label>
+      <mat-icon matPrefix fontSet="material-symbols-rounded">lock</mat-icon>
+      <input
+        matInput
+        type="password"
+        name="password"
+        autocomplete="current-password"
+        required
+        [(ngModel)]="password"
+      />
+    </mat-form-field>
+
+    <div class="login-form__options">
+      <mat-checkbox
+        name="rememberEmail"
+        [(ngModel)]="rememberEmail"
+        (change)="onRememberEmailChange()"
+      >
+        E-Mail-Adresse merken
+      </mat-checkbox>
+
+      <a routerLink="/auth/reset-password" class="login-form__aux-link">
+        Passwort vergessen
+      </a>
+    </div>
+
+    @if (errorMessage) {
+      <p class="login-form__error" role="alert">{{ errorMessage }}</p>
+    }
+
+    <button
+      mat-flat-button
+      type="submit"
+      class="login-form__submit"
+      [disabled]="loginForm.invalid"
+    >
+      Anmelden
+    </button>
+  </form>
+
+  <div class="login-page__footer">
+    <span>Noch kein Konto?</span>
+    <a routerLink="/auth/register">Jetzt registrieren</a>
+  </div>
+</section>

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.scss
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.scss
@@ -1,0 +1,143 @@
+.login-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  width: min(100%, 28rem);
+  padding: clamp(1.5rem, 2vw, 2rem);
+  color: var(--auth-body-text);
+}
+
+.login-page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.login-page__eyebrow {
+  margin: 0;
+  color: var(--auth-link-text);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.login-page__title {
+  margin: 0;
+  color: var(--auth-title-text);
+  font-size: clamp(1.75rem, 2.6vw, 2.15rem);
+  line-height: 1.15;
+}
+
+.login-page__subtitle {
+  margin: 0;
+  color: var(--auth-muted-text);
+  line-height: 1.5;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.login-form__field {
+  width: 100%;
+
+  --mat-sys-on-surface: var(--auth-form-field-text);
+  --mat-sys-on-surface-variant: var(--auth-form-field-label);
+  --mat-sys-outline: var(--auth-form-field-border);
+  --mat-sys-primary: var(--auth-form-field-focus);
+}
+
+.login-form__field ::ng-deep .mat-mdc-text-field-wrapper {
+  background: var(--auth-form-field-bg);
+  border-radius: 1rem;
+}
+
+.login-form__field ::ng-deep .mat-mdc-form-field-icon-prefix {
+  padding-right: 0.75rem;
+  color: var(--auth-muted-text);
+}
+
+.login-form__options {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  color: var(--auth-muted-text);
+}
+
+.login-form__aux-link,
+.login-page__footer a {
+  color: var(--auth-link-text);
+  font-weight: 600;
+  transition:
+    color 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.login-form__aux-link:hover,
+.login-page__footer a:hover {
+  color: var(--auth-link-hover-text);
+}
+
+.login-form__error {
+  margin: 0;
+  padding: 0.875rem 1rem;
+  border: 1px solid var(--auth-error-border);
+  border-radius: 0.9rem;
+  background: var(--auth-error-bg);
+  color: var(--auth-error-text);
+  font-size: 0.95rem;
+}
+
+.login-form__submit {
+  min-height: 3rem;
+  margin-top: 0.25rem;
+  border-radius: 999px;
+  background: var(--auth-submit-bg);
+  color: var(--auth-submit-text);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  box-shadow: none;
+  transition:
+    background-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.login-form__submit:hover:not(:disabled) {
+  background: var(--auth-submit-hover-bg);
+  transform: translateY(-1px);
+}
+
+.login-form__submit:disabled {
+  opacity: 0.6;
+}
+
+.login-page__footer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  color: var(--auth-muted-text);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 600px) {
+  .login-page {
+    gap: 1.5rem;
+    padding: 1.25rem;
+  }
+
+  .login-form__options {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .login-form__submit {
+    width: 100%;
+  }
+}

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.scss
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.scss
@@ -1,3 +1,5 @@
+@use '@angular/material' as mat;
+
 .login-page {
   display: flex;
   flex-direction: column;
@@ -11,15 +13,6 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-}
-
-.login-page__eyebrow {
-  margin: 0;
-  color: var(--auth-link-text);
-  font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
 }
 
 .login-page__title {
@@ -44,10 +37,23 @@
 .login-form__field {
   width: 100%;
 
-  --mat-sys-on-surface: var(--auth-form-field-text);
-  --mat-sys-on-surface-variant: var(--auth-form-field-label);
-  --mat-sys-outline: var(--auth-form-field-border);
-  --mat-sys-primary: var(--auth-form-field-focus);
+  @include mat.form-field-overrides(
+    (
+      outlined-container-shape: 1rem,
+      outlined-input-text-color: var(--auth-form-field-text),
+      outlined-label-text-color: var(--auth-form-field-label),
+      outlined-outline-color: var(--auth-form-field-border),
+      outlined-hover-outline-color: var(--auth-form-field-hover),
+      outlined-focus-outline-color: var(--auth-form-field-focus),
+      outlined-focus-label-text-color: var(--auth-form-field-focus),
+      outlined-error-outline-color: var(--auth-form-field-error-border),
+      outlined-error-hover-outline-color: var(--auth-form-field-error-hover),
+      outlined-error-label-text-color: var(--auth-form-field-error-label),
+      outlined-error-hover-label-text-color: var(--auth-form-field-error-hover-label),
+      outlined-error-focus-outline-color: var(--auth-form-field-error-focus-border),
+      outlined-error-focus-label-text-color: var(--auth-form-field-error-focus-label),
+    )
+  );
 }
 
 .login-form__field ::ng-deep .mat-mdc-text-field-wrapper {
@@ -67,6 +73,12 @@
   gap: 1rem;
   flex-wrap: wrap;
   color: var(--auth-muted-text);
+
+  @include mat.checkbox-overrides((
+    selected-icon-color: var(--auth-form-field-focus),
+    selected-hover-icon-color: var(--auth-checkbox-hover),
+    selected-focus-icon-color: var(--auth-checkbox-focus),
+  ))
 }
 
 .login-form__aux-link,
@@ -97,14 +109,19 @@
   min-height: 3rem;
   margin-top: 0.25rem;
   border-radius: 999px;
-  background: var(--auth-submit-bg);
-  color: var(--auth-submit-text);
   font-weight: 700;
   letter-spacing: 0.01em;
   box-shadow: none;
   transition:
     background-color 0.2s ease,
     transform 0.2s ease;
+
+  @include mat.button-overrides(
+    (
+      filled-container-color: var(--auth-submit-bg),
+      filled-label-text-color: var(--auth-submit-text),
+    )
+  );
 }
 
 .login-form__submit:hover:not(:disabled) {

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.scss
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.scss
@@ -52,6 +52,7 @@
       outlined-error-hover-label-text-color: var(--auth-form-field-error-hover-label),
       outlined-error-focus-outline-color: var(--auth-form-field-error-focus-border),
       outlined-error-focus-label-text-color: var(--auth-form-field-error-focus-label),
+      error-text-color: var(--auth-error-text),
     )
   );
 }

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.spec.ts
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoginPage } from './login-page';
+
+describe('LoginPage', () => {
+  let component: LoginPage;
+  let fixture: ComponentFixture<LoginPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LoginPage]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LoginPage);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.spec.ts
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 
 import { LoginPage } from './login-page';
@@ -10,9 +10,19 @@ describe('LoginPage', () => {
   let fixture: ComponentFixture<LoginPage>;
 
   beforeEach(async () => {
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      },
+      configurable: true,
+    });
+
     await TestBed.configureTestingModule({
       imports: [LoginPage],
       providers: [
+        provideRouter([]),
         {
           provide: AuthService,
           useValue: {
@@ -26,12 +36,6 @@ describe('LoginPage', () => {
                   email: 'test@example.com',
                 },
               }),
-          },
-        },
-        {
-          provide: Router,
-          useValue: {
-            navigate: jasmine.createSpy('navigate'),
           },
         },
       ],

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.spec.ts
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
 
 import { LoginPage } from './login-page';
+import { AuthService } from '@core/services/auth.service';
 
 describe('LoginPage', () => {
   let component: LoginPage;
@@ -8,7 +11,30 @@ describe('LoginPage', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [LoginPage]
+      imports: [LoginPage],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: {
+            login: () =>
+              of({
+                access: 'access-token',
+                refresh: 'refresh-token',
+                user: {
+                  id: 1,
+                  username: 'test-user',
+                  email: 'test@example.com',
+                },
+              }),
+          },
+        },
+        {
+          provide: Router,
+          useValue: {
+            navigate: jasmine.createSpy('navigate'),
+          },
+        },
+      ],
     })
     .compileComponents();
 

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.ts
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.ts
@@ -1,23 +1,71 @@
 import { Component, inject } from '@angular/core';
-import { Router } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
 import { AuthService } from '@core/services/auth.service';
 
 @Component({
   selector: 'app-login-page',
-  imports: [],
+  imports: [
+    FormsModule,
+    RouterLink,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+  ],
   templateUrl: './login-page.html',
   styleUrl: './login-page.scss',
 })
 export class LoginPage {
+  private readonly rememberedEmailKey = 'remembered_login_email';
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
 
   email = '';
   password = '';
   errorMessage = '';
+  rememberEmail = false;
+
+  constructor() {
+    const rememberedEmail = localStorage.getItem(this.rememberedEmailKey);
+
+    if (rememberedEmail) {
+      this.email = rememberedEmail;
+      this.rememberEmail = true;
+    }
+  }
+
+  onEmailChange(value: string): void {
+    this.email = value;
+
+    if (this.rememberEmail) {
+      localStorage.setItem(this.rememberedEmailKey, value);
+    }
+  }
+
+  onRememberEmailChange(): void {
+    if (this.rememberEmail) {
+      localStorage.setItem(this.rememberedEmailKey, this.email);
+      return;
+    }
+
+    localStorage.removeItem(this.rememberedEmailKey);
+  }
 
   onSubmit(): void {
     this.errorMessage = '';
+
+    if (this.rememberEmail) {
+      localStorage.setItem(this.rememberedEmailKey, this.email);
+    } else {
+      localStorage.removeItem(this.rememberedEmailKey);
+    }
 
     this.authService
       .login({

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.ts
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
@@ -29,7 +29,7 @@ export class LoginPage {
 
   email = '';
   password = '';
-  errorMessage = '';
+  errorMessage = signal('');
   rememberEmail = false;
 
   constructor() {
@@ -59,7 +59,7 @@ export class LoginPage {
   }
 
   onSubmit(): void {
-    this.errorMessage = '';
+    this.errorMessage.set('');
 
     if (this.rememberEmail) {
       localStorage.setItem(this.rememberedEmailKey, this.email);
@@ -76,8 +76,8 @@ export class LoginPage {
         next: () => {
           this.router.navigate(['/chat']);
         },
-        error: (error) => {
-          this.errorMessage = error?.error?.detail || 'Login fehlgeschlagen.';
+        error: () => {
+          this.errorMessage.set('Login fehlgeschlagen. E-Mail oder Passwort falsch.');
         },
       });
   }

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.ts
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.ts
@@ -7,6 +7,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { AuthService } from '@core/services/auth.service';
+import { AuthFormLayout } from '../../components/auth-form-layout/auth-form-layout';
 
 @Component({
   selector: 'app-login-page',
@@ -18,9 +19,9 @@ import { AuthService } from '@core/services/auth.service';
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
+    AuthFormLayout,
   ],
   templateUrl: './login-page.html',
-  styleUrl: './login-page.scss',
 })
 export class LoginPage {
   private readonly rememberedEmailKey = 'remembered_login_email';

--- a/frontend/app/src/app/features/auth/pages/login-page/login-page.ts
+++ b/frontend/app/src/app/features/auth/pages/login-page/login-page.ts
@@ -1,0 +1,36 @@
+import { Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { AuthService } from '@core/services/auth.service';
+
+@Component({
+  selector: 'app-login-page',
+  imports: [],
+  templateUrl: './login-page.html',
+  styleUrl: './login-page.scss',
+})
+export class LoginPage {
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+
+  email = '';
+  password = '';
+  errorMessage = '';
+
+  onSubmit(): void {
+    this.errorMessage = '';
+
+    this.authService
+      .login({
+        email: this.email,
+        password: this.password,
+      })
+      .subscribe({
+        next: () => {
+          this.router.navigate(['/chat']);
+        },
+        error: (error) => {
+          this.errorMessage = error?.error?.detail || 'Login fehlgeschlagen.';
+        },
+      });
+  }
+}

--- a/frontend/app/src/app/features/auth/pages/register-page/register-page.html
+++ b/frontend/app/src/app/features/auth/pages/register-page/register-page.html
@@ -1,0 +1,1 @@
+<p>register-page works!</p>

--- a/frontend/app/src/app/features/auth/pages/register-page/register-page.html
+++ b/frontend/app/src/app/features/auth/pages/register-page/register-page.html
@@ -79,17 +79,11 @@
       <p class="auth-form__message auth-form__message--error" role="alert">{{ errorMessage() }}</p>
     }
 
-    @if (successMessage()) {
-      <p class="auth-form__message auth-form__message--success" role="status">
-        {{ successMessage() }}
-      </p>
-    }
-
     <button
       mat-flat-button
       type="submit"
       class="auth-form__submit"
-      [disabled]="registerForm.invalid || !passwordsMatch"
+      [disabled]="registerForm.invalid"
     >
       Konto erstellen
     </button>

--- a/frontend/app/src/app/features/auth/pages/register-page/register-page.html
+++ b/frontend/app/src/app/features/auth/pages/register-page/register-page.html
@@ -1,1 +1,102 @@
-<p>register-page works!</p>
+<app-auth-form-layout
+  title="Registrieren"
+  subtitle="Erstelle dein Konto mit Benutzername, E-Mail-Adresse und Passwort."
+>
+  <form authFormContent class="auth-form" (ngSubmit)="onSubmit()" #registerForm="ngForm">
+    <mat-form-field appearance="outline" class="auth-form__field">
+      <mat-label>Benutzername</mat-label>
+      <mat-icon matPrefix fontSet="material-symbols-rounded">person</mat-icon>
+      <input
+        matInput
+        type="text"
+        name="username"
+        autocomplete="username"
+        required
+        [(ngModel)]="username"
+        #usernameModel="ngModel"
+      />
+      @if (usernameModel.invalid && usernameModel.touched) {
+        <mat-error>Bitte gib einen Benutzernamen ein.</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="auth-form__field">
+      <mat-label>E-Mail-Adresse</mat-label>
+      <mat-icon matPrefix fontSet="material-symbols-rounded">mail</mat-icon>
+      <input
+        matInput
+        type="email"
+        name="email"
+        autocomplete="email"
+        required
+        email
+        [(ngModel)]="email"
+        #emailModel="ngModel"
+      />
+      @if (emailModel.invalid && emailModel.touched) {
+        <mat-error>Bitte gib eine gültige E-Mail-Adresse ein.</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="auth-form__field">
+      <mat-label>Passwort</mat-label>
+      <mat-icon matPrefix fontSet="material-symbols-rounded">lock</mat-icon>
+      <input
+        matInput
+        type="password"
+        name="password"
+        autocomplete="new-password"
+        required
+        minlength="8"
+        [(ngModel)]="password"
+        #passwordModel="ngModel"
+      />
+      @if (passwordModel.invalid && passwordModel.touched) {
+        <mat-error>Bitte gib ein Passwort mit mindestens 8 Zeichen ein.</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="auth-form__field">
+      <mat-label>Passwort bestätigen</mat-label>
+      <mat-icon matPrefix fontSet="material-symbols-rounded">lock_reset</mat-icon>
+      <input
+        matInput
+        type="password"
+        name="passwordConfirm"
+        autocomplete="new-password"
+        required
+        [(ngModel)]="passwordConfirm"
+        #passwordConfirmModel="ngModel"
+      />
+      @if (passwordConfirmModel.touched && !passwordsMatch) {
+        <mat-error>Die Passwörter stimmen nicht überein.</mat-error>
+      } @else if (passwordConfirmModel.invalid && passwordConfirmModel.touched) {
+        <mat-error>Bitte bestätige dein Passwort.</mat-error>
+      }
+    </mat-form-field>
+
+    @if (errorMessage()) {
+      <p class="auth-form__message auth-form__message--error" role="alert">{{ errorMessage() }}</p>
+    }
+
+    @if (successMessage()) {
+      <p class="auth-form__message auth-form__message--success" role="status">
+        {{ successMessage() }}
+      </p>
+    }
+
+    <button
+      mat-flat-button
+      type="submit"
+      class="auth-form__submit"
+      [disabled]="registerForm.invalid || !passwordsMatch"
+    >
+      Konto erstellen
+    </button>
+  </form>
+
+  <ng-container authFormFooter>
+    <span>Schon registriert?</span>
+    <a routerLink="/login">Zum Login</a>
+  </ng-container>
+</app-auth-form-layout>

--- a/frontend/app/src/app/features/auth/pages/register-page/register-page.spec.ts
+++ b/frontend/app/src/app/features/auth/pages/register-page/register-page.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RegisterPage } from './register-page';
+
+describe('RegisterPage', () => {
+  let component: RegisterPage;
+  let fixture: ComponentFixture<RegisterPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RegisterPage]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(RegisterPage);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/app/src/app/features/auth/pages/register-page/register-page.spec.ts
+++ b/frontend/app/src/app/features/auth/pages/register-page/register-page.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
 
 import { RegisterPage } from './register-page';
+import { AuthService } from '@core/services/auth.service';
 
 describe('RegisterPage', () => {
   let component: RegisterPage;
@@ -8,7 +11,16 @@ describe('RegisterPage', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RegisterPage]
+      imports: [RegisterPage],
+      providers: [
+        provideRouter([]),
+        {
+          provide: AuthService,
+          useValue: {
+            register: () => of({ detail: 'Registration successful.' }),
+          },
+        },
+      ],
     })
     .compileComponents();
 

--- a/frontend/app/src/app/features/auth/pages/register-page/register-page.ts
+++ b/frontend/app/src/app/features/auth/pages/register-page/register-page.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-register-page',
+  imports: [],
+  templateUrl: './register-page.html',
+  styleUrl: './register-page.scss',
+})
+export class RegisterPage {
+
+}

--- a/frontend/app/src/app/features/auth/pages/register-page/register-page.ts
+++ b/frontend/app/src/app/features/auth/pages/register-page/register-page.ts
@@ -1,6 +1,6 @@
 import { Component, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
@@ -23,6 +23,7 @@ import { AuthFormLayout } from '../../components/auth-form-layout/auth-form-layo
 })
 export class RegisterPage {
   private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
 
   username = '';
   email = '';
@@ -52,10 +53,8 @@ export class RegisterPage {
         password_confirm: this.passwordConfirm,
       })
       .subscribe({
-        next: (response) => {
-          this.successMessage.set(
-            response.detail || 'Registrierung erfolgreich. Bitte prüfe dein E-Mail-Postfach.',
-          );
+        next: () => {
+          this.router.navigate(['/register-success']);
         },
         error: () => {
           this.errorMessage.set('Registrierung fehlgeschlagen. Bitte prüfe deine Eingaben.');

--- a/frontend/app/src/app/features/auth/pages/register-page/register-page.ts
+++ b/frontend/app/src/app/features/auth/pages/register-page/register-page.ts
@@ -1,11 +1,65 @@
-import { Component } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { AuthService } from '@core/services/auth.service';
+import { AuthFormLayout } from '../../components/auth-form-layout/auth-form-layout';
 
 @Component({
   selector: 'app-register-page',
-  imports: [],
+  imports: [
+    FormsModule,
+    RouterLink,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    AuthFormLayout,
+  ],
   templateUrl: './register-page.html',
-  styleUrl: './register-page.scss',
 })
 export class RegisterPage {
+  private readonly authService = inject(AuthService);
 
+  username = '';
+  email = '';
+  password = '';
+  passwordConfirm = '';
+  errorMessage = signal('');
+  successMessage = signal('');
+
+  get passwordsMatch(): boolean {
+    return this.password === this.passwordConfirm;
+  }
+
+  onSubmit(): void {
+    this.errorMessage.set('');
+    this.successMessage.set('');
+
+    if (!this.passwordsMatch) {
+      this.errorMessage.set('Die Passwörter stimmen nicht überein.');
+      return;
+    }
+
+    this.authService
+      .register({
+        display_name: this.username,
+        email: this.email,
+        password: this.password,
+        password_confirm: this.passwordConfirm,
+      })
+      .subscribe({
+        next: (response) => {
+          this.successMessage.set(
+            response.detail || 'Registrierung erfolgreich. Bitte prüfe dein E-Mail-Postfach.',
+          );
+        },
+        error: () => {
+          this.errorMessage.set('Registrierung fehlgeschlagen. Bitte prüfe deine Eingaben.');
+        },
+      });
+  }
 }

--- a/frontend/app/src/app/features/auth/pages/register-page/register-page.ts
+++ b/frontend/app/src/app/features/auth/pages/register-page/register-page.ts
@@ -52,7 +52,9 @@ export class RegisterPage {
       })
       .subscribe({
         next: () => {
-          this.router.navigate(['/register-success']);
+          this.router.navigate(['/register-success'], {
+            state: { fromRegisterSubmit: true },
+          });
         },
         error: () => {
           this.errorMessage.set('Registrierung fehlgeschlagen. Bitte prüfe deine Eingaben.');

--- a/frontend/app/src/app/features/auth/pages/register-page/register-page.ts
+++ b/frontend/app/src/app/features/auth/pages/register-page/register-page.ts
@@ -30,7 +30,6 @@ export class RegisterPage {
   password = '';
   passwordConfirm = '';
   errorMessage = signal('');
-  successMessage = signal('');
 
   get passwordsMatch(): boolean {
     return this.password === this.passwordConfirm;
@@ -38,7 +37,6 @@ export class RegisterPage {
 
   onSubmit(): void {
     this.errorMessage.set('');
-    this.successMessage.set('');
 
     if (!this.passwordsMatch) {
       this.errorMessage.set('Die Passwörter stimmen nicht überein.');

--- a/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.html
+++ b/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.html
@@ -2,7 +2,7 @@
   title="Registrierung erfolgreich"
   subtitle="Bitte bestätige deine E-Mail-Adresse"
 >
-  <div authFormContent class="register-success-page__content">
+  <div authFormContent>
     <p>
       Dein Konto wurde erfolgreich erstellt. Wir haben dir eine E-Mail mit einem Aktivierungslink
       gesendet. Bitte öffne dein E-Mail-Postfach und bestätige deine Registrierung, indem du auf den

--- a/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.html
+++ b/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.html
@@ -1,0 +1,20 @@
+<app-auth-form-layout
+  title="Registrierung erfolgreich"
+  subtitle="Bitte bestätige deine E-Mail-Adresse"
+>
+  <div authFormContent class="register-success-page__content">
+    <p>
+      Dein Konto wurde erfolgreich erstellt. Wir haben dir eine E-Mail mit einem Aktivierungslink
+      gesendet. Bitte öffne dein E-Mail-Postfach und bestätige deine Registrierung, indem du auf den
+      Link klickst. Erst danach kannst du dich anmelden.
+    </p>
+    <p>
+      Falls du keine E-Mail erhalten hast, überprüfe bitte auch deinen Spam-Ordner oder fordere eine
+      neue Aktivierungs-E-Mail an.
+    </p>
+  </div>
+  <ng-container authFormFooter>
+    <span>E-Mail bestätigt?</span>
+    <a routerLink="/login">Jetzt anmelden</a>
+  </ng-container>
+</app-auth-form-layout>

--- a/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.html
+++ b/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.html
@@ -2,7 +2,7 @@
   title="Registrierung erfolgreich"
   subtitle="Bitte bestätige deine E-Mail-Adresse"
 >
-  <div authFormContent>
+  <main authFormContent>
     <p>
       Dein Konto wurde erfolgreich erstellt. Wir haben dir eine E-Mail mit einem Aktivierungslink
       gesendet. Bitte öffne dein E-Mail-Postfach und bestätige deine Registrierung, indem du auf den
@@ -12,7 +12,7 @@
       Falls du keine E-Mail erhalten hast, überprüfe bitte auch deinen Spam-Ordner oder fordere eine
       neue Aktivierungs-E-Mail an.
     </p>
-  </div>
+  </main>
   <ng-container authFormFooter>
     <span>E-Mail bestätigt?</span>
     <a routerLink="/login">Jetzt anmelden</a>

--- a/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.scss
+++ b/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.scss
@@ -1,3 +1,0 @@
-.register-success-page__content {
-    max-width: 450px;
-}

--- a/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.scss
+++ b/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.scss
@@ -1,0 +1,3 @@
+.register-success-page__content {
+    max-width: 450px;
+}

--- a/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.spec.ts
+++ b/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RegisterSuccessPage } from './register-success-page';
+
+describe('RegisterSuccessPage', () => {
+  let component: RegisterSuccessPage;
+  let fixture: ComponentFixture<RegisterSuccessPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RegisterSuccessPage]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(RegisterSuccessPage);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.ts
+++ b/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { AuthFormLayout } from '../../components/auth-form-layout/auth-form-layout';
+
+@Component({
+  selector: 'app-register-success-page',
+  imports: [AuthFormLayout, RouterLink],
+  templateUrl: './register-success-page.html',
+  styleUrl: './register-success-page.scss',
+})
+export class RegisterSuccessPage {}

--- a/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.ts
+++ b/frontend/app/src/app/features/auth/pages/register-success-page/register-success-page.ts
@@ -6,6 +6,5 @@ import { AuthFormLayout } from '../../components/auth-form-layout/auth-form-layo
   selector: 'app-register-success-page',
   imports: [AuthFormLayout, RouterLink],
   templateUrl: './register-success-page.html',
-  styleUrl: './register-success-page.scss',
 })
 export class RegisterSuccessPage {}

--- a/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.html
+++ b/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.html
@@ -1,0 +1,60 @@
+<app-auth-form-layout
+  title="Neues Passwort festlegen"
+  subtitle="Erstelle ein neues Passwort für dein Konto."
+>
+  <form authFormContent class="auth-form" (ngSubmit)="onSubmit()" #resetPasswordForm="ngForm">
+    <mat-form-field appearance="outline" class="auth-form__field">
+      <mat-label>Neues Passwort</mat-label>
+      <mat-icon matPrefix fontSet="material-symbols-rounded">lock</mat-icon>
+      <input
+        matInput
+        type="password"
+        name="password"
+        autocomplete="new-password"
+        required
+        minlength="8"
+        [(ngModel)]="password"
+        #passwordModel="ngModel"
+      />
+      @if (passwordModel.invalid && passwordModel.touched) {
+        <mat-error>Bitte gib ein Passwort mit mindestens 8 Zeichen ein.</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="auth-form__field">
+      <mat-label>Neues Passwort bestätigen</mat-label>
+      <mat-icon matPrefix fontSet="material-symbols-rounded">lock_reset</mat-icon>
+      <input
+        matInput
+        type="password"
+        name="passwordConfirm"
+        autocomplete="new-password"
+        required
+        [(ngModel)]="passwordConfirm"
+        #passwordConfirmModel="ngModel"
+      />
+      @if (passwordConfirmModel.touched && !passwordsMatch) {
+        <mat-error>Die Passwörter stimmen nicht überein.</mat-error>
+      } @else if (passwordConfirmModel.invalid && passwordConfirmModel.touched) {
+        <mat-error>Bitte bestätige dein neues Passwort.</mat-error>
+      }
+    </mat-form-field>
+
+    @if (errorMessage()) {
+      <p class="auth-form__message auth-form__message--error" role="alert">{{ errorMessage() }}</p>
+    }
+
+    <button
+      mat-flat-button
+      type="submit"
+      class="auth-form__submit"
+      [disabled]="resetPasswordForm.invalid"
+    >
+      Passwort zurücksetzen
+    </button>
+  </form>
+
+  <ng-container authFormFooter>
+    <a routerLink="/login">Zurück zum Login</a>
+  </ng-container>
+</app-auth-form-layout>

--- a/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.html
+++ b/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.html
@@ -1,8 +1,8 @@
 <app-auth-form-layout
-  title="Neues Passwort festlegen"
+  title="Passwort zurücksetzen"
   subtitle="Erstelle ein neues Passwort für dein Konto."
 >
-  <form authFormContent class="auth-form" (ngSubmit)="onSubmit()" #resetPasswordForm="ngForm">
+  <form authFormContent class="auth-form" (ngSubmit)="onSubmit(resetPasswordForm)" #resetPasswordForm="ngForm">
     <mat-form-field appearance="outline" class="auth-form__field">
       <mat-label>Neues Passwort</mat-label>
       <mat-icon matPrefix fontSet="material-symbols-rounded">lock</mat-icon>
@@ -44,17 +44,26 @@
       <p class="auth-form__message auth-form__message--error" role="alert">{{ errorMessage() }}</p>
     }
 
+    @if (successMessage()) {
+      <p class="auth-form__message auth-form__message--success" role="status">
+        {{ successMessage() }}
+      </p>
+    }
+
     <button
       mat-flat-button
       type="submit"
       class="auth-form__submit"
-      [disabled]="resetPasswordForm.invalid"
+      [disabled]="resetPasswordForm.invalid || !passwordsMatch || isSubmitting() || !hasResetLink"
     >
-      Passwort zurücksetzen
+      {{ isSubmitting() ? 'Wird zurückgesetzt ...' : 'Passwort zurücksetzen' }}
     </button>
   </form>
 
   <ng-container authFormFooter>
-    <a routerLink="/login">Zurück zum Login</a>
+    <section class="footer-link-container">
+      <a routerLink="/login">Zurück zum Login</a>
+      <a routerLink="/forgot-password">E-Mail erneut senden</a>
+    </section>
   </ng-container>
 </app-auth-form-layout>

--- a/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.html
+++ b/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.html
@@ -61,9 +61,6 @@
   </form>
 
   <ng-container authFormFooter>
-    <section class="footer-link-container">
-      <a routerLink="/login">Zurück zum Login</a>
-      <a routerLink="/forgot-password">E-Mail erneut senden</a>
-    </section>
+    <a routerLink="/login">Zurück zum Login</a>
   </ng-container>
 </app-auth-form-layout>

--- a/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.scss
+++ b/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.scss
@@ -1,0 +1,6 @@
+@import '@styles/_mixins.scss';
+
+.footer-link-container {
+  @include d-flex($justify: space-between);
+  width: 100%;
+}

--- a/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.spec.ts
+++ b/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ResetPasswordPage } from './reset-password-page';
+
+describe('ResetPasswordPage', () => {
+  let component: ResetPasswordPage;
+  let fixture: ComponentFixture<ResetPasswordPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ResetPasswordPage]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ResetPasswordPage);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.spec.ts
+++ b/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 import { ResetPasswordPage } from './reset-password-page';
 
@@ -8,9 +10,9 @@ describe('ResetPasswordPage', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ResetPasswordPage]
-    })
-    .compileComponents();
+      imports: [ResetPasswordPage],
+      providers: [provideHttpClient(), provideRouter([])],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ResetPasswordPage);
     component = fixture.componentInstance;

--- a/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.ts
+++ b/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.ts
@@ -1,26 +1,106 @@
 import { Component, inject, signal } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { Router, RouterLink } from '@angular/router';
+import { FormsModule, NgForm } from '@angular/forms';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { AuthService } from '@core/services/auth.service';
+import { finalize } from 'rxjs';
 import { AuthFormLayout } from '../../components/auth-form-layout/auth-form-layout';
 
 @Component({
   selector: 'app-reset-password-page',
-  imports: [FormsModule, AuthFormLayout, RouterLink, MatButtonModule, MatInputModule, MatIconModule, MatFormFieldModule],
+  imports: [
+    FormsModule,
+    AuthFormLayout,
+    RouterLink,
+    MatButtonModule,
+    MatInputModule,
+    MatIconModule,
+    MatFormFieldModule,
+  ],
   templateUrl: './reset-password-page.html',
+  styleUrl: './reset-password-page.scss',
 })
 export class ResetPasswordPage {
+  private readonly authService = inject(AuthService);
+  private readonly route = inject(ActivatedRoute);
+
+  private readonly uid = this.normalizeResetParam(this.route.snapshot.queryParamMap.get('uid'));
+  private readonly token = this.normalizeResetParam(this.route.snapshot.queryParamMap.get('token'));
+
   password = '';
   passwordConfirm = '';
   errorMessage = signal('');
+  successMessage = signal('');
+  isSubmitting = signal(false);
 
   get passwordsMatch(): boolean {
     return this.password === this.passwordConfirm;
   }
 
-  onSubmit(): void {}
+  get hasResetLink(): boolean {
+    return Boolean(this.uid && this.token);
+  }
+
+  constructor() {
+    if (!this.hasResetLink) {
+      this.errorMessage.set(
+        'Der Link zum Zurücksetzen ist unvollständig. Bitte fordere einen neuen Link an.',
+      );
+    }
+  }
+
+  onSubmit(resetPasswordForm: NgForm): void {
+    this.errorMessage.set('');
+    this.successMessage.set('');
+
+    if (!this.hasResetLink) {
+      this.errorMessage.set(
+        'Der Link zum Zurücksetzen ist unvollständig. Bitte fordere einen neuen Link an.',
+      );
+      return;
+    }
+
+    if (!this.passwordsMatch) {
+      this.errorMessage.set('Die Passwörter stimmen nicht überein.');
+      return;
+    }
+
+    this.isSubmitting.set(true);
+
+    this.authService
+      .confirmPasswordReset({
+        uid: this.uid,
+        token: this.token,
+        password: this.password,
+        password_confirm: this.passwordConfirm,
+      })
+      .pipe(finalize(() => this.isSubmitting.set(false)))
+      .subscribe({
+        next: () => {
+          resetPasswordForm.resetForm({
+            password: '',
+            passwordConfirm: '',
+          });
+          this.successMessage.set('Dein Passwort wurde erfolgreich zurückgesetzt.');
+        },
+        error: () => {
+          this.errorMessage.set(
+            'Das Passwort konnte nicht zurückgesetzt werden. Bitte prüfe den Link oder fordere einen neuen an.',
+          );
+        },
+      });
+  }
+
+  private normalizeResetParam(value: string | null): string {
+    const normalized = (value ?? '').replace(/\s+/g, '').replace(/=3D/gi, '=');
+
+    if (normalized.startsWith('3D')) {
+      return normalized.slice(2);
+    }
+
+    return normalized;
+  }
 }

--- a/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.ts
+++ b/frontend/app/src/app/features/auth/pages/reset-password-page/reset-password-page.ts
@@ -1,0 +1,26 @@
+import { Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { AuthService } from '@core/services/auth.service';
+import { AuthFormLayout } from '../../components/auth-form-layout/auth-form-layout';
+
+@Component({
+  selector: 'app-reset-password-page',
+  imports: [FormsModule, AuthFormLayout, RouterLink, MatButtonModule, MatInputModule, MatIconModule, MatFormFieldModule],
+  templateUrl: './reset-password-page.html',
+})
+export class ResetPasswordPage {
+  password = '';
+  passwordConfirm = '';
+  errorMessage = signal('');
+
+  get passwordsMatch(): boolean {
+    return this.password === this.passwordConfirm;
+  }
+
+  onSubmit(): void {}
+}

--- a/frontend/app/src/index.html
+++ b/frontend/app/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="utf-8">
   <title>TalkCore</title>

--- a/frontend/app/src/styles/_layout.scss
+++ b/frontend/app/src/styles/_layout.scss
@@ -1,3 +1,5 @@
+@import './mixins';
+
 .shell {
   display: grid;
   grid-template-rows: 64px 1fr;
@@ -59,4 +61,8 @@ mat-toolbar.topbar.mat-toolbar-single-row {
 .main-content__inner {
   height: 100%;
   padding: 24px;
+}
+
+.main-content__center {
+  @include d-flex;
 }

--- a/frontend/app/src/styles/_layout.scss
+++ b/frontend/app/src/styles/_layout.scss
@@ -1,4 +1,4 @@
-@import './mixins';
+@import '@styles/_mixins.scss';
 
 .shell {
   display: grid;

--- a/frontend/app/src/styles/_mixins.scss
+++ b/frontend/app/src/styles/_mixins.scss
@@ -33,3 +33,11 @@
     font-variation-settings 125ms ease-in-out,
     background-color 125ms ease-in-out;
 }
+
+@mixin d-flex($direction: row, $justify: center, $align: center, $gap: 0) {
+  display: flex;
+  flex-direction: $direction;
+  justify-content: $justify;
+  align-items: $align;
+  gap: $gap;
+}

--- a/frontend/app/src/styles/_variables.scss
+++ b/frontend/app/src/styles/_variables.scss
@@ -63,19 +63,36 @@
   --card-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
 
   /* Auth */
-  --auth-title-text: #0f172a;
-  --auth-body-text: #475569;
+--auth-title-text: #0f172a;
+  --auth-body-text: #334155;
   --auth-muted-text: #64748b;
+
   --auth-link-text: #2563eb;
   --auth-link-hover-text: #1d4ed8;
+
   --auth-form-field-bg: #f8fbff;
-  --auth-form-field-border: #dbe4f0;
+  --auth-form-field-border: #e2e8f0;
+  --auth-form-field-hover: #cbd5f5;
   --auth-form-field-focus: #2563eb;
+
   --auth-form-field-text: #0f172a;
   --auth-form-field-label: #64748b;
+
+  --auth-form-field-error-border: #fca5a5;
+  --auth-form-field-error-hover: #f87171;
+  --auth-form-field-error-label: #dc2626;
+  --auth-form-field-error-hover-label: #b91c1c;
+  --auth-form-field-error-focus-border: #dc2626;
+  --auth-form-field-error-focus-label: #dc2626;
+
+  --auth-checkbox-color: #2563eb;
+  --auth-checkbox-hover: #1d4ed8;
+  --auth-checkbox-focus: #2563eb;
+
   --auth-submit-bg: #2563eb;
   --auth-submit-hover-bg: #1d4ed8;
   --auth-submit-text: #ffffff;
+
   --auth-error-bg: rgba(239, 68, 68, 0.08);
   --auth-error-border: rgba(239, 68, 68, 0.2);
   --auth-error-text: #b91c1c;
@@ -139,20 +156,37 @@
   --card-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 
   /* Auth */
-  --auth-title-text: #f8fafc;
-  --auth-body-text: #cbd5e1;
+  --auth-title-text: #f1f5f9;
+  --auth-body-text: #cbd5f5;
   --auth-muted-text: #94a3b8;
-  --auth-link-text: #7dd3fc;
-  --auth-link-hover-text: #bae6fd;
-  --auth-form-field-bg: rgba(15, 23, 42, 0.65);
+
+  --auth-link-text: #38bdf8;
+  --auth-link-hover-text: #0ea5e9;
+
+  --auth-form-field-bg: #111c2e;
   --auth-form-field-border: #334155;
+  --auth-form-field-hover: #475569;
   --auth-form-field-focus: #38bdf8;
-  --auth-form-field-text: #f8fafc;
+
+  --auth-form-field-text: #f1f5f9;
   --auth-form-field-label: #94a3b8;
-  --auth-submit-bg: #0ea5e9;
-  --auth-submit-hover-bg: #0284c7;
-  --auth-submit-text: #e0f2fe;
-  --auth-error-bg: rgba(248, 113, 113, 0.12);
-  --auth-error-border: rgba(248, 113, 113, 0.24);
-  --auth-error-text: #fecaca;
+
+  --auth-form-field-error-border: #f87171;
+  --auth-form-field-error-hover: #ef4444;
+  --auth-form-field-error-label: #f87171;
+  --auth-form-field-error-hover-label: #ef4444;
+  --auth-form-field-error-focus-border: #ef4444;
+  --auth-form-field-error-focus-label: #ef4444;
+
+  --auth-checkbox-color: #38bdf8;
+  --auth-checkbox-hover: #0ea5e9;
+  --auth-checkbox-focus: #38bdf8;
+
+  --auth-submit-bg: #38bdf8;
+  --auth-submit-hover-bg: #0ea5e9;
+  --auth-submit-text: #020617;
+
+  --auth-error-bg: rgba(239, 68, 68, 0.12);
+  --auth-error-border: rgba(239, 68, 68, 0.3);
+  --auth-error-text: #fca5a5;
 }

--- a/frontend/app/src/styles/_variables.scss
+++ b/frontend/app/src/styles/_variables.scss
@@ -61,6 +61,24 @@
   --card-bg: #ffffff;
   --card-border: #e2e8f0;
   --card-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+
+  /* Auth */
+  --auth-title-text: #0f172a;
+  --auth-body-text: #475569;
+  --auth-muted-text: #64748b;
+  --auth-link-text: #2563eb;
+  --auth-link-hover-text: #1d4ed8;
+  --auth-form-field-bg: #f8fbff;
+  --auth-form-field-border: #dbe4f0;
+  --auth-form-field-focus: #2563eb;
+  --auth-form-field-text: #0f172a;
+  --auth-form-field-label: #64748b;
+  --auth-submit-bg: #2563eb;
+  --auth-submit-hover-bg: #1d4ed8;
+  --auth-submit-text: #ffffff;
+  --auth-error-bg: rgba(239, 68, 68, 0.08);
+  --auth-error-border: rgba(239, 68, 68, 0.2);
+  --auth-error-text: #b91c1c;
 }
 
 :root.dark-theme {
@@ -119,4 +137,22 @@
   --card-bg: #1e293b;
   --card-border: #334155;
   --card-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+
+  /* Auth */
+  --auth-title-text: #f8fafc;
+  --auth-body-text: #cbd5e1;
+  --auth-muted-text: #94a3b8;
+  --auth-link-text: #7dd3fc;
+  --auth-link-hover-text: #bae6fd;
+  --auth-form-field-bg: rgba(15, 23, 42, 0.65);
+  --auth-form-field-border: #334155;
+  --auth-form-field-focus: #38bdf8;
+  --auth-form-field-text: #f8fafc;
+  --auth-form-field-label: #94a3b8;
+  --auth-submit-bg: #0ea5e9;
+  --auth-submit-hover-bg: #0284c7;
+  --auth-submit-text: #e0f2fe;
+  --auth-error-bg: rgba(248, 113, 113, 0.12);
+  --auth-error-border: rgba(248, 113, 113, 0.24);
+  --auth-error-text: #fecaca;
 }

--- a/frontend/app/src/styles/global.scss
+++ b/frontend/app/src/styles/global.scss
@@ -73,8 +73,3 @@ a {
   @include button-transition();
 }
 
-.center-div {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}

--- a/frontend/app/tsconfig.json
+++ b/frontend/app/tsconfig.json
@@ -16,7 +16,8 @@
     "module": "preserve",
     "baseUrl": ".",
     "paths": {
-      "@core/*": ["src/app/core/*"]
+      "@core/*": ["src/app/core/*"],
+      "@styles/*": ["src/styles/*"]
     }
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
## Summary

This PR implements the complete authentication flow for TalkCore, including registration, account activation, login, and password reset functionality.

## Implemented

### Authentication Flow
- user registration with username, email and password
- account activation via email link
- login with email and password
- logout handling (token cleanup handled in service)

### Password Reset Flow
- request password reset via email input
- backend-triggered email with reset link (if email exists)
- password reset page accessed via secure link
- setting a new password with confirmation

### Route Protection
- implementation of guards to control access to auth-related routes
- prevention of direct navigation to restricted pages via URL input
- protected flows:
  - forgot-password-success only accessible after request
  - register-success only after successful registration
  - activate and reset-password only via email links

## Details

The authentication flow is fully aligned with the backend API and ensures a consistent and secure user experience.

Guards were introduced to enforce proper navigation flows and prevent unintended access to system routes.

## Notes

- this PR focuses on authentication only
- no chat or messaging UI is included
- further UX improvements and edge case handling can be added later